### PR TITLE
Use .gitkeep to keep empty data directory

### DIFF
--- a/src/data/keep_directory_in_git.txt
+++ b/src/data/keep_directory_in_git.txt
@@ -1,1 +1,0 @@
-This file ensures that the data/ directory exists in a fresh checkout.


### PR DESCRIPTION
Thought I could let you know about what I thought was the default way of keeping an empty directory in git.

Looking for some documentation on it, I had my own little TIL, though: a `.gitkeep` file isn't actually the officially blessed way of doing that, it's just _some_ file which will make git keep the directory - interesting!

I'm still putting this PR up as I think a `.gitkeep` is a neat and self-explanatory method of achieving the purpose, maybe you like it, too.

Here's a StackOverflow on the topic: https://stackoverflow.com/a/7229996